### PR TITLE
install pi-camera on pi-gen environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,8 @@ class CustomInstallCommand(install):
     def run(self):
         # Make sure we're installing on a Raspberry Pi
         on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-        if not on_rtd:
+        pi_gen = os.environ.get('PI_GEN', None) == 'True'
+        if not on_rtd and not pi_gen:
             try:
                 with io.open('/proc/cpuinfo', 'r') as cpuinfo:
                     found = False


### PR DESCRIPTION
It appears that pi-camera can't be installed on [pi-get](https://github.com/RPi-Distro/pi-gen). This is a suggested way to bypass this problem, If there is another way you want this to be done I will gladly help.